### PR TITLE
Skip pthread find on apple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,6 @@ find_package(PNG REQUIRED)
 #
 
 if(APPLE)
-	find_package(pthread REQUIRED)
 	find_package(iconv REQUIRED)
 endif()
 


### PR DESCRIPTION
Per https://github.com/GabrieleGiuseppini/Floating-Sandbox/issues/32#issuecomment-1267315790, removing (initially commenting out) the pthread find allows `cmake` to complete on macOS.