### PR TITLE
Updates to documentation

### DIFF
--- a/BUILD-Ubuntu.md
+++ b/BUILD-Ubuntu.md
@@ -189,7 +189,7 @@ Configured wxWidgets 3.1.4 for `x86_64-pc-linux-gnu'
 ```
 Now, it's time to build wxWidgets - launch this and go grab a cup of coffee:
 ```
-make install
+make install -j$(nproc)
 ```
 After the build is complete and installed, you should see the following under your new `~/fs_libs/wxWidgets` directory:
 ```
@@ -221,6 +221,7 @@ Luckily you're going to find a pre-cooked `UserSettings.example-linux.cmake` fil
 cd ~/git/Floating-Sandbox
 cp UserSettings.example-linux.cmake UserSettings.cmake
 ```
+Remember to change the user name in the file to reflect your home folder.
 On the other hand, if you've customized paths of checkouts and library roots, just make your own `UserSettings.cmake`, eventually using `UserSettings.example-linux.cmake` as a template.
 ### Building
 We're gonna build Floating Sandbox in a folder named `build` under its checkout root, and make it install under `~/floating-sandbox`. Note that the `INSTALL` target will create the whole directory structure as expected by the simulator, including all resource and ship files.
@@ -229,7 +230,7 @@ cd ~/git/Floating-Sandbox
 mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DFS_BUILD_BENCHMARKS=OFF -DFS_USE_STATIC_LIBS=ON -DwxWidgets_USE_DEBUG=OFF -DwxWidgets_USE_UNICODE=ON -DwxWidgets_USE_STATIC=ON -DFS_INSTALL_DIRECTORY=~/floating-sandbox ..
-make install
+make install -j$(nproc)
 ```
 ### Running
 At this moment you should have the game neatly laid out under your `~/floating-sandbox` directory:
@@ -248,6 +249,6 @@ drwxr-xr-x  2 gg gg     57344 mei 23 15:57 Ships/
 ```
 To start the game, go into that directory and launch `FloatingSandbox`. 
 
-Note that many Linux distributions nowadays use Wayland for their desktop environments, and Floating Sandbox will encounter an error when launching. To rectify this, set the environment variable "GDK_BACKEND" to "x11".
+Note that many Linux distributions nowadays use Wayland for their desktop environments, and Floating Sandbox will sometimes encounter an error when launching. To rectify this, set the environment variable "GDK_BACKEND" to "x11".
 
 Enjoy!

--- a/README.md
+++ b/README.md
@@ -60,9 +60,6 @@ The bottleneck at the moment is the spring relaxation algorithm (aka rigidity si
 
 Rendering is a different story. At some point I've moved all the rendering code to a separate thread, allowing simulation updates and rendering to run in parallel. Obviously, only multi-core boxes benefit from parallel rendering, and boxes with very slow or emulated graphics hardware benefit the most. In any case, at this moment rendering requires a fraction of the time needed for updating the simulation, so CPU speed still dominates the performance you get, compared to GPU speed.
 
-# Troubleshooting
-Many Linux distributions now use Wayland for their desktop environments, and Floating Sandbox will encounter an error when launching. To rectify this, set the environment variable "GDK_BACKEND" to "x11".
-
 # Building the Game
 I build this game with Visual Studio 2022 (thus with full C++ 17 support) on Windows. From time to time I also build on Ubuntu to ensure the codebase is still portable.
 


### PR DESCRIPTION
I recently rebuilt Floating Sandbox on Linux (specifically OpenSUSE Tumbleweed), and following the documentation near-verbatim now resulted in a perfect build first time.
However, there were some bits of the documentation that needed updating, specifically reverting a previous warning I had put about bugs on Wayland (it seems to be fixed on newer releases) in the README. In addition, I added the -j$(nproc) argument in the build instructions to make in order to compile with all threads instead of building with a single core. This results in the compile being much much faster, especially on CPUs with plenty of cores.