### PR TITLE
Fix missing 'template' keyword on dependent template names

### DIFF
--- a/Sources/ShipBuilderLib/Tools/TextureEraserTool.cpp
+++ b/Sources/ShipBuilderLib/Tools/TextureEraserTool.cpp
@@ -41,7 +41,7 @@ TextureEraserTool<TLayerType>::TextureEraserTool(
     : Tool(
         toolType,
         controller)
-    , mOriginalLayerClone(mController.GetModelController().CloneExistingLayer<TLayerType>())
+    , mOriginalLayerClone(mController.GetModelController().template CloneExistingLayer<TLayerType>())
     , mTempVisualizationDirtyTextureRegion()
     , mEngagementData()
     , mIsShiftDown(false)
@@ -356,7 +356,7 @@ void TextureEraserTool<TLayerType>::EndEngagement()
     assert(!mTempVisualizationDirtyTextureRegion);
 
     // Re-take original layer clone
-    mOriginalLayerClone = mController.GetModelController().CloneExistingLayer<TLayerType>();
+    mOriginalLayerClone = mController.GetModelController().template CloneExistingLayer<TLayerType>();
 }
 
 template<LayerType TLayerType>

--- a/Sources/ShipBuilderLib/Tools/TextureMagicWandTool.cpp
+++ b/Sources/ShipBuilderLib/Tools/TextureMagicWandTool.cpp
@@ -49,7 +49,7 @@ void TextureMagicWandTool<TLayerType>::OnLeftMouseDown()
     {
         // Take clone of current layer
         auto layerDirtyStateClone = mController.GetModelController().GetDirtyState();
-        auto layerClone = mController.GetModelController().CloneExistingLayer<TLayerType>();
+        auto layerClone = mController.GetModelController().template CloneExistingLayer<TLayerType>();
 
         // Do edit
 


### PR DESCRIPTION
### Problem

`ShipBuilderLib` calls the dependent template member `ModelController::CloneExistingLayer<T>()` without the `template` disambiguator. Per `[temp.names]`, the keyword is required when a dependent name is followed by an explicit template argument list.

MSVC accepts the code in its default (permissive) mode, so the Windows build is unaffected — but Clang and GCC reject it:

```
error: missing 'template' keyword prior to dependent template name 'CloneExistingLayer'
```

This blocks the build on macOS and on Linux with a recent Clang.

### Fix

Adds the `template` keyword at the three affected call sites:

- `Sources/ShipBuilderLib/Tools/TextureEraserTool.cpp` (x2)
- `Sources/ShipBuilderLib/Tools/TextureMagicWandTool.cpp` (x1)

No behavior change. Verified with a full build on macOS (Apple Silicon, Clang).
